### PR TITLE
feat: forbid default exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 node_modules/

--- a/index.js
+++ b/index.js
@@ -141,8 +141,8 @@ module.exports = {
 
         // Import
         'import/no-cycle': 'off',
-        'import/prefer-default-export': 'off',
         'import/no-default-export': 'error',
+        'import/prefer-default-export': 'off',
 
         // React: JSX
         'react/jsx-no-constructed-context-values': 'error',

--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ module.exports = {
         // Import
         'import/no-cycle': 'off',
         'import/prefer-default-export': 'off',
+        'import/no-default-export': 'error',
 
         // React: JSX
         'react/jsx-no-constructed-context-values': 'error',


### PR DESCRIPTION
### Summary of Changes

Default exports must no longer be used since they don't work well with rename refactorings. Instead use named exports.