### PR TITLE
fix: import rules not working

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,13 @@
 module.exports = {
     root: true,
     parserOptions: {
+        tsconfigRootDir: __dirname,
         project: './tsconfig.json',
+    },
+    settings: {
+        jest: {
+            version: 28,
+        },
     },
     extends: './index.js',
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 module.exports = {
-    extends: ['airbnb-typescript', 'airbnb/hooks', 'prettier'],
+    extends: [
+        'plugin:import/recommended',
+        'plugin:import/typescript',
+        'airbnb-typescript',
+        'airbnb/hooks',
+        'prettier'
+    ],
 
     plugins: [
         '@typescript-eslint',


### PR DESCRIPTION
### Summary of Changes

Most rules of the ESLint import plugin did not work in TypeScript files. This should be fixed now.