### PR TITLE
fix: disable rules `vitest/no-hooks` and `vitest/no-large-snapshots`

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = {
                 'vitest/max-expects': 'off',
                 'vitest/max-nested-describes': 'off',
                 'vitest/no-hooks': 'off',
-                "vitest/no-large-snapshots": "off",
+                'vitest/no-large-snapshots': 'off',
             },
         },
     ],

--- a/index.js
+++ b/index.js
@@ -181,8 +181,10 @@ module.exports = {
             files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
             extends: ['plugin:vitest/all', 'plugin:testing-library/react'],
             rules: {
-                'max-expects': 'off',
-                'max-nested-describes': 'off',
+                'vitest/max-expects': 'off',
+                'vitest/max-nested-describes': 'off',
+                'vitest/no-hooks': 'off',
+                "vitest/no-large-snapshots": "off",
             },
         },
     ],


### PR DESCRIPTION
### Summary of Changes

* Disable rules `vitest/no-hooks` and `vitest/no-large-snapshots`
* Disable rules `vitest/max-expects` and `vitest/max-nested-describes` properly this time
