### PR TITLE
feat: allow conditional in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,8 @@ module.exports = {
             rules: {
                 'vitest/max-expects': 'off',
                 'vitest/max-nested-describes': 'off',
+                'vitest/no-conditional-in-test': 'off',
+                'vitest/no-conditional-expect': 'off',
                 'vitest/no-hooks': 'off',
                 'vitest/no-large-snapshots': 'off',
             },


### PR DESCRIPTION
### Summary of Changes

* Turn off rule `vitest/no-conditional-in-test`
* Turn off rule `vitest/no-conditional-expect`

When working with TypeScript conditionals are difficult to avoid, e.g. to tell the compiler that something really has type `X`.